### PR TITLE
tests: deflake Avro schemaless parsing by comparing dimension names order-agnostically

### DIFF
--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -342,7 +342,11 @@ public class AvroStreamInputRowParserTest
 
   static void assertInputRowCorrect(InputRow inputRow, List<String> expectedDimensions, boolean isFromPigAvro)
   {
-    Assert.assertEquals(expectedDimensions, inputRow.getDimensions());
+    final java.util.List<String> exp = new java.util.ArrayList<>(expectedDimensions);
+    final java.util.List<String> act = new java.util.ArrayList<>(inputRow.getDimensions());
+    java.util.Collections.sort(exp);
+    java.util.Collections.sort(act);
+    Assert.assertEquals("Dimension names differ (order-agnostic)", exp, act);
     Assert.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
 
     // test dimensions


### PR DESCRIPTION
### **What is the purpose of this PR?**
Make the Avro schemaless ingestion tests deterministic under randomized iteration orders. This PR removes an order dependency in test assertions so the tests no longer fail when collection iteration order changes (as exercised by NonDex).
### **Why the test fails**
In schemaless mode the set of dimension names is discovered from the input row and then exposed as a list whose order is not guaranteed. The existing assertion compared:

Assert.assertEquals(expectedDimensions, inputRow.getDimensions());

This is order-sensitive. When a randomized iteration order is used (e.g., NonDex shuffling of map/set order), the same dimension names can appear in a different order, causing a spurious test failure.
### **How to reproduce the test failure**
On the commit before this change:
# Regular run (passes)
mvn -pl extensions-core/avro-extensions \
  -Dtest=org.apache.druid.data.input.AvroStreamInputFormatTest#testParseSchemaless \
  test

# NonDex run (fails intermittently)
mvn -pl extensions-core/avro-extensions \
  edu.illinois:nondex-maven-plugin:2.1.1:nondex \
  -Dtest=org.apache.druid.data.input.AvroStreamInputFormatTest#testParseSchemaless \
  -DnondexRuns=10


Artifacts I collected:
Before fix: regular pass log (druid_regular_before.log) and NonDex failure log (druid_nondex_before.log).
After fix: NonDex pass logs for both AvroStreamInputFormatTest#testParseSchemaless and AvroStreamInputRowParserTest#testParseSchemaless
(nondex_after_format.log, nondex_after_parser.log).


### **Expected results**
Regular runs pass.
NonDex runs (10 shuffled seeds) also pass.
### **Actual results (before this PR)**
Regular runs pass.
NonDex runs fail intermittently due to different orderings of the same dimension names.

### **Description of fix**
Make the assertion order-agnostic by sorting copies of the expected and actual lists before comparing. Small and strictly test-only change.

File: extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java

-    Assert.assertEquals(expectedDimensions, inputRow.getDimensions());
+    final java.util.List<String> exp = new java.util.ArrayList<>(expectedDimensions);
+    final java.util.List<String> act = new java.util.ArrayList<>(inputRow.getDimensions());
+    java.util.Collections.sort(exp);
+    java.util.Collections.sort(act);
+    org.junit.Assert.assertEquals("Dimension names differ (order-agnostic)", exp, act);


The helper is used by both of the Avro schemaless tests:
AvroStreamInputFormatTest#testParseSchemaless
AvroStreamInputRowParserTest#testParseSchemaless
Both now pass under 10 NonDex seeds locally.

### **Why this fix is minimal and safe**
Test-only change; no production code touched.
Keeps the semantic check (same dimension names) while removing accidental ordering assumptions.
Mirrors reviewer guidance seen in prior discussions around these tests (compare names ignoring order).

Regular test runs: pass.
NonDex (-DnondexRuns=10): pass for the two tests above.
Logs are attached in the submission package:
druid_regular_before.log
druid_nondex_before.log
nondex_after_format.log
nondex_after_parser.log

